### PR TITLE
remove duplicate definition (already defined in pmmp)

### DIFF
--- a/src/onebone/boat/entity/Boat.php
+++ b/src/onebone/boat/entity/Boat.php
@@ -25,8 +25,6 @@ class Boat extends Vehicle{
 
 	public const ACTION_ROW_RIGHT = 128;
 	public const ACTION_ROW_LEFT = 129;
-	public const DATA_PADDLE_TIME_LEFT = 13;
-	public const DATA_PADDLE_TIME_RIGHT = 14;
 
 	/** @var float */
 	public $height = 0.455;


### PR DESCRIPTION
## Introduction
@PresentKim 
Thank u for merging my PRs, and sorry for my mistake.
This patch remove duplicate constants definition already defined in `Entity` class of PMMP.